### PR TITLE
npm start でサーバー起動や watch などするようにした

### DIFF
--- a/app.js
+++ b/app.js
@@ -33,7 +33,15 @@ app.use(session({
   saveUninitialized: true
 }))
 
-app.use(express.static(path.join(__dirname, 'web/dist')));
+if (process.env.WATCHING) {
+  app.use(express.static(path.join(__dirname, 'web/.tmp')));
+  app.use(express.static(path.join(__dirname, 'web/app')));
+  app.use('/bower_components', express.static(path.join(__dirname, 'web/bower_components')));
+} else {
+  app.use(express.static(path.join(__dirname, 'web/dist')));
+}
+
+
 app.use(suppressStatusCode);
 app.use(resJsonWithStatusCode);
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "scripts": {
-    "start": "node ./bin/www"
+    "start": "./start.sh"
   },
   "dependencies": {
     "app-root-path": "^1.0.0",
@@ -27,5 +27,8 @@
     "mysql": "^2.9.0",
     "serve-favicon": "~2.2.0",
     "socket.io": "^1.3.7"
+  },
+  "devDependencies": {
+    "nodemon": "^1.8.1"
   }
 }

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+terminate() {
+  kill %1
+  kill %2
+}
+
+WATCHING=1 nodemon -L bin/www &
+cd web && npm run watch &
+
+trap terminate SIGINT
+wait


### PR DESCRIPTION
Fix #9 

`npm start` で以下を実行します。
- サーバーの起動
- サーバー側の `.js` ファイルの watch
- クライアント側のファイルのビルド
- クライアント側のファイルの watch